### PR TITLE
Update info page content and plotting tweaks

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,6 @@
         <div class="column is-12">
           <div class="notification is-light is-size-7" style="line-height:1.3">
             <strong>Site purpose:</strong> Operational & diagnostic monitoring of the four‑component ROMY ring‑laser gyroscope. Figures auto‑refresh; click any image to enlarge.<br>
-            <strong>Key pages:</strong> Sagnac Spectra (frequency stability), Beat Drift (long‑term frequency evolution & MLTI / maintenance), Backscatter (horizontal ring monobeam diagnostics), Beam Wander (alignment), Environmental & Barometric (drivers), Live Data (direct feeds).<br>
             <strong>References:</strong> <a href="https://www.science.org/content/article/buried-lasers-will-sense-earths-spin-and-quakes-doing-twist" target="_blank" rel="noopener">Science Feature 2017</a> | <a href="https://doi.org/10.1093/gji/ggaa614" target="_blank" rel="noopener">GJI 2021 ROMY Paper</a>.<br>
             <strong>Credits:</strong> Site & layout: C. Bürgmann. Processing / plotting scripts: A. Brotzer. Contributions: H. Igel, F. Bernauer. <a href="info.html"><span class="icon"><i class="fas fa-circle-info"></i></span>Full info & guide</a>.
           </div>

--- a/docs/info.html
+++ b/docs/info.html
@@ -23,23 +23,22 @@
   <section class="section">
     <div class="container content is-size-6">
       <h2 class="title is-3 has-text-primary"><i class="fas fa-circle-info mr-2"></i>Purpose</h2>
-      <p>This site provides near real‑time and recent historical monitoring products for the multicomponent ring‑laser gyroscope system <strong>ROMY</strong> (ROtational Motions in seismologY) near Munich, Germany. The focus is expert operational awareness: instrument health, data quality, dominant disturbances, and environmental coupling.</p>
+      <p>This site provides near real‑time and recent historical monitoring products for the multicomponent ring‑laser gyroscope system <strong>ROMY</strong> (ROtational Motions in seismologY) near Munich, Germany. The focus is operational awareness.</p>
 
       <h3 class="title is-4 mt-5"><i class="fas fa-images mr-2"></i>Using the Figures</h3>
       <ul>
-        <li>Images auto‑refresh (5–60 min cadence depending on page). A small cache‑buster query string forces reload.</li>
-        <li>Click any figure (cursor turns pointer) to open a larger lightbox view.</li>
-        <li>If a figure fails to generate, a placeholder image ("oops") is shown; persistent placeholders indicate upstream processing issues.</li>
+        <li>Click any figure to open a larger lightbox view.</li>
+        <li>Images refresh approximately <span class="tag is-light is-size-7">XX&nbsp;min</span> (page specific cadence).</li>
       </ul>
 
       <h3 class="title is-4 mt-5"><i class="fas fa-sitemap mr-2"></i>Page Overview</h3>
       <dl>
         <dt><strong>Home</strong></dt>
-        <dd>Quick oscilloscope snapshot of the four active ring beat signals (immediate functional status).</dd>
+        <dd>Oscilloscope snapshot of the four ring beat signals and quick-look status context.</dd>
         <dt><strong>Sagnac Spectra</strong></dt>
-        <dd>Hourly Sagnac signal power spectral densities (PSD) per ring plus combined views for diurnal/operational drift assessment.</dd>
+        <dd>Hourly Sagnac signal power spectral densities per ring with combined multi-ring comparisons for drift assessment.</dd>
         <dt><strong>Beam Wander</strong></dt>
-        <dd>Recent beam position evolution (alignment stability) and associated helicorder for context.</dd>
+        <dd>Beam walk monitoring from IDS cameras, showing spot trajectories and Gaussian-fit diagnostics.</dd>
         <dt><strong>Beat Drift</strong></dt>
         <dd>14‑day evolution of Sagnac beat frequencies, maintenance / MLTI intervention markers, and MLTI density proxy.</dd>
         <dt><strong>Backscatter</strong></dt>
@@ -49,38 +48,20 @@
         <dt><strong>Barometric</strong></dt>
         <dd>Focused air pressure & infrasound monitoring (higher temporal detail / filtering variants).</dd>
         <dt><strong>Live Data</strong></dt>
-        <dd>Direct access (or links) to raw / near real‑time channels and quick health indicators.</dd>
+        <dd>Interactive archive browser for daily helicorder and rotation spectra images (last few days per ring).</dd>
         <dt><strong>Info</strong></dt>
-        <dd>This guide, credits, and reference material.</dd>
+        <dd>This guide, credits, and further reading.</dd>
       </dl>
 
-      <h3 class="title is-4 mt-5"><i class="fas fa-link mr-2"></i>Key References</h3>
+      <h3 class="title is-4 mt-5"><i class="fas fa-link mr-2"></i>Further Reading</h3>
       <ul>
         <li>Science Magazine Feature (2017): <a href="https://www.science.org/content/article/buried-lasers-will-sense-earths-spin-and-quakes-doing-twist" target="_blank" rel="noopener">Buried lasers will sense Earth's spin...</a></li>
         <li>GJI Open Access Article (2021): <a href="https://doi.org/10.1093/gji/ggaa614" target="_blank" rel="noopener">ROMY: a multicomponent ring laser for geodesy and geophysics</a></li>
       </ul>
 
       <h3 class="title is-4 mt-5"><i class="fas fa-users mr-2"></i>Credits</h3>
-      <p class="is-size-7">Website design & implementation: <strong>Christopher Bürgmann</strong> | Scientific plotting / processing scripts: <strong>Andreas Brotzer</strong> | Concept & contributions: <strong>Heiner Igel</strong>, <strong>Felix Bernauer</strong>. Underlying research supported by the ROMY ERC Advanced Grant and institutional partners.</p>
+      <p class="is-size-7">Scientific plotting & automation: <strong>Andreas Brotzer</strong> | Website design & operations: <strong>Christopher Burgmann</strong> | Concept & contributions: <strong>Heiner Igel</strong>, <strong>Felix Bernauer</strong>. Underlying research supported by the ROMY ERC Advanced Grant and institutional partners.</p>
 
-      <h3 class="title is-4 mt-5"><i class="fas fa-triangle-exclamation mr-2"></i>Operational Notes</h3>
-      <ul>
-        <li>Grey / empty intervals in spectra denote missing or unusable data (not low signal).</li>
-        <li>Vertical red (MLTI) or yellow (maintenance) bands annotate intervention periods; interpret adjacent frequency excursions cautiously.</li>
-        <li>Backscatter correction line (black dashed) should converge toward cleaned signal; divergence flags calibration drift.</li>
-        <li>Environmental correlation: inspect tilt / temperature shifts when long‑term Sagnac drifts accelerate.</li>
-      </ul>
-
-      <h3 class="title is-4 mt-5"><i class="fas fa-terminal mr-2"></i>Data Access</h3>
-      <p>For raw rotational / translational time series, contact the ROMY operations team or consult internal seedlink endpoints (not publicly listed here). Future public APIs may expose low‑latency rotational channels.</p>
-
-      <h3 class="title is-4 mt-5"><i class="fas fa-tools mr-2"></i>Planned Enhancements</h3>
-      <ul>
-        <li>Per‑figure historical archive links.</li>
-        <li>Automatic anomaly flagging (threshold & model‑based).</li>
-        <li>Overlay of predicted tidal / polar motion signatures.</li>
-        <li>Download buttons for last 24 h PNG / CSV exports.</li>
-      </ul>
     </div>
   </section>
 

--- a/python_scripts/makeplot_environmentals.py
+++ b/python_scripts/makeplot_environmentals.py
@@ -619,7 +619,7 @@ def __makeplot(bws):
         ax[0].set_ylim(f_min-0.001, f_max+0.001)
 
         ax[0].ticklabel_format(useOffset=False)
-        ax[0].set_ylabel(f"R{config['ring']} $\delta f$ (Hz)", fontsize=font)
+        ax[0].set_ylabel("RZ $\delta f$ (HZ)", fontsize=font)
     except:
         pass
 

--- a/python_scripts/romy_make_helicorder.py
+++ b/python_scripts/romy_make_helicorder.py
@@ -126,6 +126,7 @@ def make_helicorder(tr, tints, dt, title):
     ax.set_yticklabels(yticklabels)
     ax.grid(False)
     ax.set_title(title)
+    ax.minorticks_on()
 
     # >>> Tight y-limits so 00:00 and 23:00 fill the frame
     m = 0.8

--- a/python_scripts/romy_make_sagnac_spectrum.py
+++ b/python_scripts/romy_make_sagnac_spectrum.py
@@ -125,12 +125,13 @@ def make_sagnac_figure(freq: np.ndarray,
 
     fig, ax = plt.subplots(1, 1, figsize=(12, 8))
 
-    # Draw from hour 23 down to 00 so red-ish late hours don't cover everything
-    draw_order = sorted(hours_present, reverse=True)
+    # Draw chronologically but ensure later hours appear on top via z-order
+    draw_order = sorted(hours_present)
 
     handles = []
     labels  = []
     for h in draw_order:
+        z_base = 10 + h  # keep later hours visually on top
         line, = ax.plot(
             freq,
             hour_psds[h],
@@ -138,7 +139,7 @@ def make_sagnac_figure(freq: np.ndarray,
             alpha=CFG["alpha"],
             lw=1.0,
             label=f"{h:02d}:00",
-            zorder=1,  # all the same; visual stacking is set by draw order
+            zorder=z_base,
         )
         handles.append(line)
         labels.append(f"{h:02d}:00")


### PR DESCRIPTION
## Summary
- streamline the home/info pages by removing the key pages callout, rewriting the info page content, renaming the references section, and updating credits
- add minor ticks to helicorder plots, shift the oscilloscope footer strip to the right, and draw newer Sagnac spectra on top
- label the environmental overview's first panel with “RZ δf (HZ)”

## Testing
- python -m compileall python_scripts/romy_make_helicorder.py python_scripts/romy_make_oszi.py python_scripts/romy_make_sagnac_spectrum.py python_scripts/makeplot_environmentals.py


------
https://chatgpt.com/codex/tasks/task_e_68dc0f2375d483309478c4c225637144